### PR TITLE
Fix response body replacement in hyphenator middleware

### DIFF
--- a/Classes/Middleware/HyphenatorMiddleware.php
+++ b/Classes/Middleware/HyphenatorMiddleware.php
@@ -9,6 +9,7 @@ use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use StraschekIo\Hyphenator\Parser\HyphenParser;
 use StraschekIo\Hyphenator\Repository\TermRepository;
+use TYPO3\CMS\Core\Http\StreamFactory;
 
 final class HyphenatorMiddleware implements MiddlewareInterface
 {
@@ -34,8 +35,10 @@ final class HyphenatorMiddleware implements MiddlewareInterface
         if ($terms = $this->termRepository->fetchAll()) {
             $output = $response->getBody()->__toString();
             $parsedOutput = $this->parser->replace($terms, $output);
-            $response->getBody()->rewind();
-            $response->getBody()->write($parsedOutput);
+            $stream = (new StreamFactory())->createStream($parsedOutput);
+            $response = $response
+                ->withBody($stream)
+                ->withoutHeader('Content-Length');
         }
         return $response;
     }

--- a/Classes/Middleware/HyphenatorMiddleware.php
+++ b/Classes/Middleware/HyphenatorMiddleware.php
@@ -13,33 +13,44 @@ use TYPO3\CMS\Core\Http\StreamFactory;
 
 final class HyphenatorMiddleware implements MiddlewareInterface
 {
-    /**
-     * @var TermRepository
-     */
-    private $termRepository;
-
-    /**
-     * @var HyphenParser
-     */
-    private $parser;
-
-    public function __construct(HyphenParser $parser, TermRepository $termRepository)
-    {
-        $this->termRepository = $termRepository;
-        $this->parser = $parser;
+    public function __construct(
+        private readonly HyphenParser $parser,
+        private readonly TermRepository $termRepository,
+    ) {
     }
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $response = $handler->handle($request);
-        if ($terms = $this->termRepository->fetchAll()) {
-            $output = $response->getBody()->__toString();
-            $parsedOutput = $this->parser->replace($terms, $output);
-            $stream = (new StreamFactory())->createStream($parsedOutput);
-            $response = $response
-                ->withBody($stream)
-                ->withoutHeader('Content-Length');
+
+        if (!$this->isHtmlResponse($response)) {
+            return $response;
         }
-        return $response;
+
+        $terms = $this->termRepository->fetchAll();
+        if ($terms === []) {
+            return $response;
+        }
+
+        $body = (string) $response->getBody();
+        $parsedBody = $this->parser->replace($terms, $body);
+
+        if ($parsedBody === $body) {
+            return $response;
+        }
+
+        $stream = (new StreamFactory())->createStream($parsedBody);
+
+        return $response
+            ->withBody($stream)
+            ->withoutHeader('Content-Length');
+    }
+
+    private function isHtmlResponse(ResponseInterface $response): bool
+    {
+        return str_contains(
+            strtolower($response->getHeaderLine('Content-Type')),
+            'text/html'
+        );
     }
 }


### PR DESCRIPTION
The middleware previously rewrote the existing response body stream using rewind() and write().

This caused trailing content from the original response to remain in the stream whenever the parsed HTML output became shorter than the original output (e.g. due to DOMDocument normalizing the HTML during parsing/saving).

As a result, parts of the previous response body could appear appended after the closing </html> tag.

The fix replaces the response body with a newly created stream instead of rewriting the existing one in place.